### PR TITLE
Fix cancel/back on android for async call

### DIFF
--- a/Bulboss.MvvmCross.Plugins.UserInteraction.Droid/AlertDialogCancelListener.cs
+++ b/Bulboss.MvvmCross.Plugins.UserInteraction.Droid/AlertDialogCancelListener.cs
@@ -1,0 +1,20 @@
+using Android.Content;
+using System;
+
+namespace Bulboss.MvvmCross.Plugins.UserInteraction.Droid
+{
+   public class AlertDialogCancelListener : Java.Lang.Object, IDialogInterfaceOnCancelListener
+   {
+      readonly Action<IDialogInterface> _cancelAction;
+
+      public AlertDialogCancelListener(Action<IDialogInterface> cancelAction)
+      {
+         _cancelAction = cancelAction;   
+      }
+
+      public void OnCancel(IDialogInterface dialog)
+      {
+         _cancelAction(dialog);
+      }
+   }
+}

--- a/Bulboss.MvvmCross.Plugins.UserInteraction.Droid/Bulboss.MvvmCross.Plugins.UserInteraction.Droid.csproj
+++ b/Bulboss.MvvmCross.Plugins.UserInteraction.Droid/Bulboss.MvvmCross.Plugins.UserInteraction.Droid.csproj
@@ -68,6 +68,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AlertDialogCancelListener.cs" />
     <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="UserInteraction.cs" />
     <Compile Include="Plugin.cs" />

--- a/Bulboss.MvvmCross.Plugins.UserInteraction.Droid/UserInteraction.cs
+++ b/Bulboss.MvvmCross.Plugins.UserInteraction.Droid/UserInteraction.cs
@@ -40,17 +40,12 @@ namespace Bulboss.MvvmCross.Plugins.UserInteraction.Droid
 				if (CurrentActivity == null) return;
 				new AlertDialog.Builder(CurrentActivity)
 					.SetMessage(message)
-						.SetTitle(title)
-						.SetPositiveButton(okButton, delegate {
-							if (answer != null)
-								answer(true);
-						})
-						.SetNegativeButton(cancelButton, delegate {	
-							if (answer != null)
-								answer(false);
-						})
-						.Show();
-			}, null);
+					.SetTitle(title)
+					.SetPositiveButton(okButton, (sender, args) => answer?.Invoke(true))
+					.SetNegativeButton(cancelButton, (sender, args) => answer?.Invoke(false))
+					.SetOnCancelListener(new AlertDialogCancelListener(dialog => answer?.Invoke(false)))
+					.Show();
+         }, null);
 		}
 
 		public Task<bool> ConfirmAsync(string message, string title = "", string okButton = "OK", string cancelButton = "Cancel")


### PR DESCRIPTION
Fixes issue where if cancelled by clicking off the alert dialog or using the back key the Async call would never finish.